### PR TITLE
Add victimIsOwnedTitan to callback parameters 

### DIFF
--- a/S2.ClientKillCallback/mod.json
+++ b/S2.ClientKillCallback/mod.json
@@ -3,5 +3,5 @@
 	"Description": "Adds a client side callback triggered when any player dies.\nvoid AddClientCallback_OnPlayerKilled(void functionref(ObituaryCallbackParams{entity victim, entity attacker, int damageSourceId, int scriptDamageType}) customCallback)",
 	"LoadPriority": 1,
 	"RequiredOnClient": false,
-	"Version": "2.0.0"
+	"Version": "2.0.1"
 }

--- a/S2.ClientKillCallback/mod/scripts/vscripts/client/cl_obituary.gnut
+++ b/S2.ClientKillCallback/mod/scripts/vscripts/client/cl_obituary.gnut
@@ -22,6 +22,7 @@ global struct ObituaryCallbackParams
 	entity attacker
 	int damageSourceId
 	int scriptDamageType
+	bool victimIsOwnedTitan
 }
 /////////////////
 
@@ -318,6 +319,7 @@ function Obituary( entity attacker, string attackerClass, entity victim, int scr
 		params.attacker = attacker
 		params.damageSourceId = damageSourceId
 		params.scriptDamageType = scriptDamageType
+		params.victimIsOwnedTitan = victimIsOwnedTitan
 
 		callback( params )
 	}


### PR DESCRIPTION
Allows differentiation between player-controlled titan kills and player kills by adding victimIsOwnedTitan to the callback parameters.